### PR TITLE
Fix GetCoordinateBoundsForCamera iOS implementation.

### DIFF
--- a/src/libs/Mapbox.Maui/Platforms/iOS/MapboxViewHandler.Controller.cs
+++ b/src/libs/Mapbox.Maui/Platforms/iOS/MapboxViewHandler.Controller.cs
@@ -16,7 +16,7 @@ partial class MapboxViewHandler : IMapboxController
 		var xbounds = mapView.MapboxMap().CoordinateBoundsForCameraBounds(xcameraOptions);
 
 		return new CoordinateBounds(
-			xbounds.Southeast.ToMapPosition(),
+			xbounds.Southwest.ToMapPosition(),
 			xbounds.Northeast.ToMapPosition(),
 			xbounds.InfiniteBounds
 			);


### PR DESCRIPTION
The iOS implementation of the `GetCoordinateBoundsForCamera` method returns south east instead of south west, resulting in incorrect coordinate bounds for the area.

This commit changes fixes the issue.

PS: Apologies for the entire file being marked as changed. I committed directly through GitHub and it appears to have change the file. If you would like, please feel free to discard this PR and implement the change directly.