### PR TITLE
Add `uint` handling to Wrap in AdditionalExtensions for iOS

### DIFF
--- a/src/libs/Mapbox.Maui/Platforms/iOS/AdditionalExtensions.cs
+++ b/src/libs/Mapbox.Maui/Platforms/iOS/AdditionalExtensions.cs
@@ -194,6 +194,7 @@ public static partial class AdditionalExtensions
         {
             bool value => NSNumber.FromBoolean(value),
             int value => NSNumber.FromLong(value),
+            uint value => NSNumber.FromUInt32(value),
             long value => NSNumber.FromLong((nint)value),
             float value => NSNumber.FromDouble(value),
             double value => NSNumber.FromDouble(value),


### PR DESCRIPTION
When the `Wrap` method is called on a `uint` value,  the type mapper did not have handling for the `uint` type and would fall through to the NotSupportedException at the end of the method.

This error occurred when using the `LayerPosition.At` builder method, which accepts a `uint` as a layer position.